### PR TITLE
added .raml to list of default file suffixes.

### DIFF
--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/settings/YamlSettings.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/settings/YamlSettings.java
@@ -27,7 +27,7 @@ import static java.util.Arrays.asList;
  */
 public class YamlSettings {
     public static final String FILE_SUFFIXES_KEY = "sonar.yaml.file.suffixes";
-    public static final String FILE_SUFFIXES_DEFAULT_VALUE = ".yaml,.yml";
+    public static final String FILE_SUFFIXES_DEFAULT_VALUE = ".yaml,.yml,.raml";
 
 
     /**

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/languages/YamlLanguageTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/languages/YamlLanguageTest.java
@@ -36,7 +36,7 @@ public class YamlLanguageTest {
     @Test
     public void defaultSuffixes() {
         settings.setProperty(YamlSettings.FILE_SUFFIXES_KEY, "");
-        Assert.assertArrayEquals(new String[] { ".yaml", ".yml" }, yaml.getFileSuffixes());
+        Assert.assertArrayEquals(new String[] { ".yaml", ".yml", ".raml" }, yaml.getFileSuffixes());
     }
 
     @Test


### PR DESCRIPTION
[RAML](https://raml.org/) is a API description language based on YAML. i think *.raml files would benefit from same checks *.yaml files do.