### PR TITLE
several warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-
-# YAML SonarQube Plugin
+YAML SonarQube Plugin
+=====================
 
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.sbaudoin/sonar-yaml-plugin.svg?label=Maven%20Central)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.github.sbaudoin%22%20AND%20a%3A%22sonar-yaml-plugin%22)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-YAML SonarQube Plugin
-=====================
+
+# YAML SonarQube Plugin
 
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.sbaudoin/sonar-yaml-plugin.svg?label=Maven%20Central)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.github.sbaudoin%22%20AND%20a%3A%22sonar-yaml-plugin%22)

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/checks/CheckRepository.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/checks/CheckRepository.java
@@ -25,7 +25,7 @@ public class CheckRepository {
     public static final String REPOSITORY_KEY = "yaml";
     public static final String REPOSITORY_NAME = "YAML Analyzer";
 
-    private static final List<Class> CHECK_CLASSES = Arrays.asList(
+    private static final List<Class<? extends YamlCheck>> CHECK_CLASSES = Arrays.asList(
             BracesCheck.class,
             BracketsCheck.class,
             ColonsCheck.class,
@@ -70,7 +70,7 @@ public class CheckRepository {
      *
      * @return the rule key of the check {@link ParsingErrorCheck}
      */
-    public static Class getParsingErrorCheckClass() {
+    public static Class<? extends YamlCheck> getParsingErrorCheckClass() {
         return ParsingErrorCheck.class;
     }
 
@@ -79,7 +79,7 @@ public class CheckRepository {
      *
      * @return all check classes
      */
-    public static List<Class> getCheckClasses() {
+    public static List<Class<? extends YamlCheck>> getCheckClasses() {
         return CHECK_CLASSES;
     }
 

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlRulesDefinition.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlRulesDefinition.java
@@ -32,17 +32,17 @@ public class YamlRulesDefinition implements RulesDefinition {
      */
     public static final String RULES_DEFINITION_FOLDER = "org/sonar/l10n/yaml/rules/yaml";
 
-
     @Override
     public void define(Context context) {
         NewRepository repository = context.createRepository(CheckRepository.REPOSITORY_KEY, YamlLanguage.KEY).setName(CheckRepository.REPOSITORY_NAME);
 
         RuleMetadataLoader metadataLoader = new RuleMetadataLoader(RULES_DEFINITION_FOLDER);
+        @SuppressWarnings("rawtypes")
         List<Class> allCheckClasses = new ArrayList<>(CheckRepository.getCheckClasses());
         metadataLoader.addRulesByAnnotatedClass(repository, allCheckClasses);
 
         // Declare rule templates
-        for(NewRule rule : repository.rules()) {
+        for (NewRule rule : repository.rules()) {
             if (CheckRepository.getTemplateRuleKeys().contains(rule.key())) {
                 rule.setTemplate(true);
             }

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlRulesDefinition.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlRulesDefinition.java
@@ -32,6 +32,7 @@ public class YamlRulesDefinition implements RulesDefinition {
      */
     public static final String RULES_DEFINITION_FOLDER = "org/sonar/l10n/yaml/rules/yaml";
 
+
     @Override
     public void define(Context context) {
         NewRepository repository = context.createRepository(CheckRepository.REPOSITORY_KEY, YamlLanguage.KEY).setName(CheckRepository.REPOSITORY_NAME);

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/highlighting/YamlHighlightingTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/highlighting/YamlHighlightingTest.java
@@ -15,23 +15,23 @@
  */
 package com.github.sbaudoin.sonar.plugins.yaml.highlighting;
 
-import com.github.sbaudoin.sonar.plugins.yaml.Utils;
-import com.github.sbaudoin.sonar.plugins.yaml.checks.YamlSourceCode;
-import org.junit.Rule;
-import org.junit.Test;
-import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.highlighting.TypeOfText;
-import org.sonar.api.utils.log.LogTester;
-import org.sonar.api.utils.log.LoggerLevel;
-
-import java.io.IOException;
-import java.util.Optional;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.github.sbaudoin.sonar.plugins.yaml.Utils;
+import com.github.sbaudoin.sonar.plugins.yaml.checks.YamlSourceCode;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.batch.sensor.highlighting.TypeOfText;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
 
 public class YamlHighlightingTest {
     @Rule

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/highlighting/YamlHighlightingTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/highlighting/YamlHighlightingTest.java
@@ -15,23 +15,22 @@
  */
 package com.github.sbaudoin.sonar.plugins.yaml.highlighting;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
-
-import java.io.IOException;
-import java.util.Optional;
-
 import com.github.sbaudoin.sonar.plugins.yaml.Utils;
 import com.github.sbaudoin.sonar.plugins.yaml.checks.YamlSourceCode;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 public class YamlHighlightingTest {
     @Rule

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/linecounter/LineCountDataTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/linecounter/LineCountDataTest.java
@@ -15,10 +15,10 @@
  */
 package com.github.sbaudoin.sonar.plugins.yaml.linecounter;
 
+import junit.framework.TestCase;
+
 import java.util.Arrays;
 import java.util.HashSet;
-
-import junit.framework.TestCase;
 
 public class LineCountDataTest extends TestCase {
     public void testAll() {

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/linecounter/LineCountDataTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/linecounter/LineCountDataTest.java
@@ -15,10 +15,10 @@
  */
 package com.github.sbaudoin.sonar.plugins.yaml.linecounter;
 
-import junit.framework.TestCase;
-
 import java.util.Arrays;
 import java.util.HashSet;
+
+import junit.framework.TestCase;
 
 public class LineCountDataTest extends TestCase {
     public void testAll() {
@@ -27,9 +27,9 @@ public class LineCountDataTest extends TestCase {
         assertNull(lcd.effectiveCommentLines());
         assertNull(lcd.linesOfCodeLines());
 
-        lcd = new LineCountData(5, new HashSet(Arrays.asList(1, 2)), new HashSet(Arrays.asList(3, 4)));
+        lcd = new LineCountData(5, new HashSet<Integer>(Arrays.asList(1, 2)), new HashSet<Integer>(Arrays.asList(3, 4)));
         assertEquals(new Integer(5), lcd.linesNumber());
-        assertEquals(new HashSet(Arrays.asList(3, 4)), lcd.effectiveCommentLines());
-        assertEquals(new HashSet(Arrays.asList(1, 2)), lcd.linesOfCodeLines());
+        assertEquals(new HashSet<Integer>(Arrays.asList(3, 4)), lcd.effectiveCommentLines());
+        assertEquals(new HashSet<Integer>(Arrays.asList(1, 2)), lcd.linesOfCodeLines());
     }
 }


### PR DESCRIPTION
md-lint heading style, unused import (organize imports from ide called), added some generics

Side note: `testGetYamlFile` is failing already in master on my workstation.
```
Failed tests:
  YamlSourceCodeTest.testGetYamlFile:44 expected:<---[
dict: {}
fdgsfg: fgdfg
- fdgfd:
    fgdfg: fgfgfgf
    - fgf:]
    # Comment> but was:<---[
dict: {}
fdgsfg: fgdfg
- fdgfd:
    fgdfg: fgfgfgf
]   - fgf:
    # Comment>
```