### PR TITLE
new template - YAML documents should contain a required key

### DIFF
--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/checks/CheckRepository.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/checks/CheckRepository.java
@@ -47,6 +47,7 @@ public class CheckRepository {
             NewLinesCheck.class,
             OctalValuesCheck.class,
             ParsingErrorCheck.class,
+            RequiredKeyCheck.class,
             TrailingSpacesCheck.class,
             TruthyCheck.class,
             QuotedStringsCheck.class
@@ -54,7 +55,8 @@ public class CheckRepository {
 
     private static final List<String> TEMPLATE_RULE_KEYS = Arrays.asList(
             "ForbiddenKeyCheck",
-            "ForbiddenValueCheck"
+            "ForbiddenValueCheck",
+            "RequiredKeyCheck"
     );
 
 

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/checks/RequiredKeyCheck.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/checks/RequiredKeyCheck.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2018-2019, Sylvain Baudoin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.sbaudoin.sonar.plugins.yaml.checks;
+
+import com.github.sbaudoin.yamllint.LintScanner;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+import org.yaml.snakeyaml.reader.StreamReader;
+import org.yaml.snakeyaml.tokens.KeyToken;
+import org.yaml.snakeyaml.tokens.ScalarToken;
+import org.yaml.snakeyaml.tokens.Token;
+import org.yaml.snakeyaml.tokens.ValueToken;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.io.IOException;
+
+/**
+ * Class used to implement to required key/scalar value checks
+ */
+@Rule(key = "RequiredKeyCheck")
+public class RequiredKeyCheck extends YamlCheck {
+    private static final Logger LOGGER = Loggers.get(RequiredKeyCheck.class);
+    private int ISSUE_LINE = 0;
+    private final int FIRST_COLUMN = 0; 
+
+    @RuleProperty(key = "parent-key-name", description = "Regexp that matches the prerequisite parent-key-name")
+    String keyName;
+
+    @RuleProperty(key = "parent-key-value", description = "Regexp that matches the value for the prerequisite parent-key-name")
+    String keyValue;
+
+    @RuleProperty(key = "required-key-name", description = "Regexp that matches the required key name for the required-key-name")
+    String requiredKeyName;
+
+    @Override
+    public void validate() {
+        if (yamlSourceCode == null) {
+            throw new IllegalStateException("Source code not set, cannot validate anything");
+        }
+
+        try {
+            LintScanner parser = new LintScanner(new StreamReader(yamlSourceCode.getContent()));
+            if (!yamlSourceCode.hasCorrectSyntax()) {
+                LOGGER.warn("Syntax error found, cannot continue checking keys: " + yamlSourceCode.getSyntaxError().getMessage());
+                return;
+            }
+            boolean isKeyPresent = false;
+            boolean isRequiredKeyPresent = false;
+            while (parser.hasMoreTokens()) {
+                Token t1 = parser.getToken();
+                if (t1 instanceof KeyToken && parser.hasMoreTokens()) {
+                    // Peek token (instead of get) in order to leave it in the stack so that it processed again when looping
+                    Token t2 = parser.peekToken();
+                    if (t2 instanceof ScalarToken) {
+                        if( ((ScalarToken) t2).getValue().matches(keyName) ) {
+                            boolean isNewMatch = checkValue(parser, t2);
+                            if(isKeyPresent && isNewMatch && !isRequiredKeyPresent) {
+                                checkNextToken();
+                            }
+                            isKeyPresent = isNewMatch;
+                            isRequiredKeyPresent = (isNewMatch) ? false : isRequiredKeyPresent ;
+                            ISSUE_LINE = (isNewMatch) ? t2.getStartMark().getLine() : ISSUE_LINE;
+
+                        } else if( ((ScalarToken) t2).getValue().matches(requiredKeyName) && isKeyPresent ) {
+                            isRequiredKeyPresent = true;
+                        }     
+                    }
+                }
+            }
+            if (!isRequiredKeyPresent && isKeyPresent) {
+                checkNextToken();
+            }
+        } catch (IOException e) {
+            // Should not happen: a first call to getYamlSourceCode().getContent() was done in the constructor of
+            // the YamlSourceCode instance of this check, but in case...
+            LOGGER.warn("Cannot read source code", e);
+        }
+    }
+
+
+    private boolean checkValue(LintScanner parser, Token t2) {
+        boolean isKeyPresent = false;
+        parser.getToken();
+        if (parser.peekToken() instanceof ValueToken) {
+            parser.getToken();
+            Token t3 = parser.peekToken();
+            if (t3 instanceof ScalarToken) {
+                Matcher m = Pattern.compile("(?m)" + keyValue).matcher(((ScalarToken)t3).getValue());
+                if (m.find()) {
+                    isKeyPresent = true;
+                }
+            }
+        }
+        return isKeyPresent;
+    }
+
+
+    /**
+     * Callback method used to implement a specific behavior when a key matching the {@code key-name} regex is NOT found.
+     * Implementations should carefully use the {@code peekToken()} and {@code getToken()} methods to make sure relevant,
+     * unmatched tokens still remain in the stack of the scanner.
+     */
+    private void checkNextToken() {
+        // Just report new error
+        addViolation("Required " + requiredKeyName + " key not found");
+    }
+
+    /**
+     * Adds a violation to the analyzed Yaml source
+     *
+     * @param message the message that describes the violation
+     */
+    private void addViolation(String message) {
+        getYamlSourceCode()
+            .addViolation(new YamlIssue(
+                getRuleKey(),
+                message,
+                ISSUE_LINE + 1,
+                FIRST_COLUMN + 1
+            )
+        );
+    }
+}

--- a/src/main/resources/org/sonar/l10n/yaml/rules/yaml/RequiredKeyCheck.html
+++ b/src/main/resources/org/sonar/l10n/yaml/rules/yaml/RequiredKeyCheck.html
@@ -1,0 +1,60 @@
+<p>Use this rule to control that the YAML documents do contain a required key. Parameters can be defined as a regular expression.
+
+<h2>Parameters</h2>
+<dl>
+    <dt>parent-key-name</dt>
+    <dd>Regular expression that matches prerequisite key name</dd>
+</dl>
+<dl>
+    <dt>parent-key-value</dt>
+    <dd>Regular expression that matches the value for the prerequisite key name</dd>
+</dl>
+<dl>
+    <dt>required-key-name</dt>
+    <dd>Regular expression that matches the required key name for the key-name</dd>
+</dl>
+
+<h2>Examples</h2>
+<p>With <code>parent-key-name = kind</code> and <code>parent-key-value = Pod</code> and <code>required-key-name = readinessProbe</code> 
+    the following code snippet would <strong>PASS</strong>:</p>
+<pre>
+    apiVersion: v1
+    kind: Pod
+    metadata:
+        labels:
+            test: liveness
+        name: liveness-http
+    spec:
+        containers:
+            - name: liveness
+                image: k8s.gcr.io/liveness
+                args:
+                - /server
+                readinessProbe:
+                    httpGet:
+                        path: /healthz
+                        port: 8080
+                        httpHeaders:
+                        - name: Custom-Header
+                        value: Awesome
+                    initialDelaySeconds: 3
+                    periodSeconds: 3
+</pre>
+<p>the following code snippets would <strong>FAIL</strong>:</p>
+<pre>
+    apiVersion: v1
+    kind: Pod
+    metadata:
+        labels:
+            test: liveness
+        name: liveness-http
+    spec:
+        containers:
+            - name: liveness
+                image: k8s.gcr.io/liveness
+                args:
+                    - /server
+                initialDelaySeconds: 3
+                periodSeconds: 3
+</pre>
+

--- a/src/main/resources/org/sonar/l10n/yaml/rules/yaml/RequiredKeyCheck.html
+++ b/src/main/resources/org/sonar/l10n/yaml/rules/yaml/RequiredKeyCheck.html
@@ -10,12 +10,16 @@
     <dd>Regular expression that matches the value for the prerequisite key name</dd>
 </dl>
 <dl>
+  <dt>parent-key-name-root</dt>
+  <dd>Filter only root keys for the parent-key-name | yes | not | anywhere</dd>
+</dl>
+<dl>
     <dt>required-key-name</dt>
     <dd>Regular expression that matches the required key name for the key-name</dd>
 </dl>
 
 <h2>Examples</h2>
-<p>With <code>parent-key-name = kind</code> and <code>parent-key-value = Pod</code> and <code>required-key-name = readinessProbe</code> 
+<p>With <code>parent-key-name = kind</code> and <code>parent-key-value = Pod</code> and  <code>parent-key-name-root = yes</code> and  <code>required-key-name = readinessProbe</code> 
     the following code snippet would <strong>PASS</strong>:</p>
 <pre>
     apiVersion: v1

--- a/src/main/resources/org/sonar/l10n/yaml/rules/yaml/RequiredKeyCheck.json
+++ b/src/main/resources/org/sonar/l10n/yaml/rules/yaml/RequiredKeyCheck.json
@@ -1,0 +1,13 @@
+{
+  "title": "YAML documents should contain some keys",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "convention"
+  ],
+  "defaultSeverity": "Major"
+}

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/checks/CheckRepositoryTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/checks/CheckRepositoryTest.java
@@ -23,12 +23,12 @@ public class CheckRepositoryTest extends TestCase {
     }
 
     public void testGetCheckClasses() {
-        assertEquals(24, CheckRepository.getCheckClasses().size());
+        assertEquals(25, CheckRepository.getCheckClasses().size());
         assertTrue(CheckRepository.getCheckClasses().contains(ParsingErrorCheck.class));
     }
 
     public void testGetTemplateRuleKeys() {
-        assertEquals(2, CheckRepository.getTemplateRuleKeys().size());
+        assertEquals(3, CheckRepository.getTemplateRuleKeys().size());
         assertTrue(CheckRepository.getTemplateRuleKeys().contains("ForbiddenKeyCheck"));
     }
 }

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/checks/RequiredKeyCheckTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/checks/RequiredKeyCheckTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2018-2019, Sylvain Baudoin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.sbaudoin.sonar.plugins.yaml.checks;
+
+import com.github.sbaudoin.sonar.plugins.yaml.Utils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+public class RequiredKeyCheckTest {
+    @Rule
+    public LogTester logTester = new LogTester();
+
+    @Test
+    public void testCheck() {
+        assertNotNull(new RequiredKeyCheck());
+    }
+
+    @Test
+    public void testFailedValidateNoSource() {
+        try {
+            new RequiredKeyCheck().validate();
+            fail("No source code should raise an exception");
+        } catch (IllegalStateException e) {
+            assertEquals("Source code not set, cannot validate anything", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFailedValidateIOException() throws IOException {
+        // Prepare error
+        YamlSourceCode code = getSourceCode("required-key-01.yaml", false);
+        YamlSourceCode spy = spy(code);
+        when(spy.getContent()).thenThrow(new IOException("Cannot read file"));
+
+        RequiredKeyCheck check = new RequiredKeyCheck();
+        check.keyName = "required";
+
+        check.setYamlSourceCode(spy);
+        check.validate();
+        assertEquals(1, logTester.logs(LoggerLevel.WARN).size());
+        assertThat(logTester.logs(LoggerLevel.WARN).get(0), containsString("Cannot read source code"));
+        assertEquals(0, spy.getYamlIssues().size());
+    }
+
+    @Test
+    public void testValidateSyntaxError() throws IOException {
+        RequiredKeyCheck check = new RequiredKeyCheck();
+        check.keyName = "required";
+
+        // Syntax error
+        YamlSourceCode code = getSourceCode("required-key-01.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertEquals(1, logTester.logs(LoggerLevel.WARN).size());
+        assertThat(logTester.logs(LoggerLevel.WARN).get(0), containsString("Syntax error found, cannot continue checking keys: syntax error: expected <block end>, but found '-'"));
+        assertFalse(code.hasCorrectSyntax());
+        assertNull(code.getSyntaxError().getRuleKey());
+        assertEquals("syntax error: expected <block end>, but found '-'", code.getSyntaxError().getMessage());
+        assertEquals(4, code.getSyntaxError().getLine());
+        assertEquals(3, code.getSyntaxError().getColumn());
+        assertEquals(0, code.getYamlIssues().size());
+    }
+
+    @Test
+    public void testValidateNoIssue() throws IOException {
+        RequiredKeyCheck check = new RequiredKeyCheck();
+        check.keyName = "kind";
+        check.keyValue = "Deployment";
+        check.requiredKeyName = "readinessProbe";
+
+        // Syntax 1
+        YamlSourceCode code = getSourceCode("required-key-02.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+
+        // Syntax 2
+        code = getSourceCode("required-key-03.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+    }
+
+    @Test
+    public void testValidateWithRequiredKey1() throws IOException {
+        RequiredKeyCheck check = new RequiredKeyCheck();
+        check.keyName = "kind";
+        check.keyValue = "Deployment";
+        check.requiredKeyName = "readinessProbe";
+
+        YamlSourceCode code = getSourceCode("required-key-04.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+        assertEquals(1, code.getYamlIssues().size());
+        assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(0).getMessage());
+        assertEquals(2, code.getYamlIssues().get(0).getLine());
+        assertEquals(1, code.getYamlIssues().get(0).getColumn());
+    }
+
+    @Test
+    public void testValidateWithRequiredKey2() throws IOException {
+        RequiredKeyCheck check = new RequiredKeyCheck();
+        check.keyName = "kind";
+        check.keyValue = "Deployment";
+        check.requiredKeyName = "readinessProbe";
+
+        YamlSourceCode code = getSourceCode("required-key-05.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+        assertEquals(1, code.getYamlIssues().size());
+        assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(0).getMessage());
+        assertEquals(15, code.getYamlIssues().get(0).getLine());
+        assertEquals(1, code.getYamlIssues().get(0).getColumn());
+    }
+
+    @Test
+    public void testValidateWithRequiredKey3() throws IOException {
+        RequiredKeyCheck check = new RequiredKeyCheck();
+        check.keyName = "kind";
+        check.keyValue = "Deployment";
+        check.requiredKeyName = "readinessProbe";
+
+        YamlSourceCode code = getSourceCode("required-key-06.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+        assertEquals(2, code.getYamlIssues().size());
+        
+        assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(0).getMessage());
+        assertEquals(3, code.getYamlIssues().get(0).getLine());
+        assertEquals(1, code.getYamlIssues().get(0).getColumn());
+
+        assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(1).getMessage());
+        assertEquals(25, code.getYamlIssues().get(1).getLine());
+        assertEquals(1, code.getYamlIssues().get(1).getColumn());
+    }
+
+    @Test
+    public void testValidateWithRequiredKey4() throws IOException {
+        RequiredKeyCheck check = new RequiredKeyCheck();
+        check.keyName = "kind";
+        check.keyValue = "Deployment";
+        check.requiredKeyName = "readinessProbe";
+
+        YamlSourceCode code = getSourceCode("required-key-07.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+        assertEquals(2, code.getYamlIssues().size());
+
+        assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(0).getMessage());
+        assertEquals(3, code.getYamlIssues().get(0).getLine());
+        assertEquals(1, code.getYamlIssues().get(0).getColumn());
+
+        assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(0).getMessage());
+        assertEquals(60, code.getYamlIssues().get(1).getLine());
+        assertEquals(1, code.getYamlIssues().get(1).getColumn());
+    }
+
+    private YamlSourceCode getSourceCode(String filename, boolean filter) throws IOException {
+        return new YamlSourceCode(Utils.getInputFile("required-key/" + filename), Optional.of(filter));
+    }
+}

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/checks/RequiredKeyCheckTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/checks/RequiredKeyCheckTest.java
@@ -57,6 +57,7 @@ public class RequiredKeyCheckTest {
 
         RequiredKeyCheck check = new RequiredKeyCheck();
         check.keyName = "required";
+        check.isKeyNameAtRoot = "yes";
 
         check.setYamlSourceCode(spy);
         check.validate();
@@ -69,6 +70,7 @@ public class RequiredKeyCheckTest {
     public void testValidateSyntaxError() throws IOException {
         RequiredKeyCheck check = new RequiredKeyCheck();
         check.keyName = "required";
+        check.isKeyNameAtRoot = "yes";
 
         // Syntax error
         YamlSourceCode code = getSourceCode("required-key-01.yaml", false);
@@ -86,10 +88,7 @@ public class RequiredKeyCheckTest {
 
     @Test
     public void testValidateNoIssue() throws IOException {
-        RequiredKeyCheck check = new RequiredKeyCheck();
-        check.keyName = "kind";
-        check.keyValue = "Deployment";
-        check.requiredKeyName = "readinessProbe";
+        RequiredKeyCheck check = getRequiredCheck("kind", "Deployment", "yes", "readinessProbe");
 
         // Syntax 1
         YamlSourceCode code = getSourceCode("required-key-02.yaml", false);
@@ -106,10 +105,7 @@ public class RequiredKeyCheckTest {
 
     @Test
     public void testValidateWithRequiredKey1() throws IOException {
-        RequiredKeyCheck check = new RequiredKeyCheck();
-        check.keyName = "kind";
-        check.keyValue = "Deployment";
-        check.requiredKeyName = "readinessProbe";
+        RequiredKeyCheck check = getRequiredCheck("kind", "Deployment", "yes", "readinessProbe");
 
         YamlSourceCode code = getSourceCode("required-key-04.yaml", false);
         check.setYamlSourceCode(code);
@@ -123,10 +119,7 @@ public class RequiredKeyCheckTest {
 
     @Test
     public void testValidateWithRequiredKey2() throws IOException {
-        RequiredKeyCheck check = new RequiredKeyCheck();
-        check.keyName = "kind";
-        check.keyValue = "Deployment";
-        check.requiredKeyName = "readinessProbe";
+        RequiredKeyCheck check = getRequiredCheck("kind", "Deployment", "yes", "readinessProbe");
 
         YamlSourceCode code = getSourceCode("required-key-05.yaml", false);
         check.setYamlSourceCode(code);
@@ -140,10 +133,7 @@ public class RequiredKeyCheckTest {
 
     @Test
     public void testValidateWithRequiredKey3() throws IOException {
-        RequiredKeyCheck check = new RequiredKeyCheck();
-        check.keyName = "kind";
-        check.keyValue = "Deployment";
-        check.requiredKeyName = "readinessProbe";
+        RequiredKeyCheck check = getRequiredCheck("kind", "Deployment", "yes", "readinessProbe");
 
         YamlSourceCode code = getSourceCode("required-key-06.yaml", false);
         check.setYamlSourceCode(code);
@@ -162,10 +152,7 @@ public class RequiredKeyCheckTest {
 
     @Test
     public void testValidateWithRequiredKey4() throws IOException {
-        RequiredKeyCheck check = new RequiredKeyCheck();
-        check.keyName = "kind";
-        check.keyValue = "Deployment";
-        check.requiredKeyName = "readinessProbe";
+        RequiredKeyCheck check = getRequiredCheck("kind", "Deployment", "yes", "readinessProbe");
 
         YamlSourceCode code = getSourceCode("required-key-07.yaml", false);
         check.setYamlSourceCode(code);
@@ -180,6 +167,40 @@ public class RequiredKeyCheckTest {
         assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(0).getMessage());
         assertEquals(60, code.getYamlIssues().get(1).getLine());
         assertEquals(1, code.getYamlIssues().get(1).getColumn());
+    }
+
+    @Test
+    public void testValidateWithRequiredKey5() throws IOException {
+        RequiredKeyCheck check = getRequiredCheck("kind", "Deployment", "yes", "readinessProbe");
+
+        YamlSourceCode code = getSourceCode("required-key-08.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+        assertEquals(0, code.getYamlIssues().size());
+    }
+
+    @Test
+    public void testValidateWithRequiredKey6() throws IOException {
+        RequiredKeyCheck check = getRequiredCheck("kind", "Deployment", "not", "readinessProbe");
+
+        YamlSourceCode code = getSourceCode("required-key-08.yaml", false);
+        check.setYamlSourceCode(code);
+        check.validate();
+        assertTrue(code.hasCorrectSyntax());
+        assertEquals(1, code.getYamlIssues().size());
+        assertEquals("Required readinessProbe key not found", code.getYamlIssues().get(0).getMessage());
+        assertEquals(9, code.getYamlIssues().get(0).getLine());
+        assertEquals(1, code.getYamlIssues().get(0).getColumn());
+    }
+
+    private RequiredKeyCheck getRequiredCheck(String keyName, String keyValue, String isKeyNameAtRoot, String requiredKeyName) {
+      RequiredKeyCheck check = new RequiredKeyCheck();
+      check.keyName = keyName;
+      check.keyValue = keyValue;
+      check.isKeyNameAtRoot = isKeyNameAtRoot;
+      check.requiredKeyName = requiredKeyName;
+      return check;
     }
 
     private YamlSourceCode getSourceCode(String filename, boolean filter) throws IOException {

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlRulesDefinitionTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlRulesDefinitionTest.java
@@ -36,7 +36,7 @@ public class YamlRulesDefinitionTest extends TestCase {
         assertNotNull(aRule);
         assertEquals("For readability and maintenance YAML documents should have a consistent indentation", aRule.name());
 
-        assertEquals(2L, repository.rules().stream().filter(Rule::template).map(Rule::key).count());
+        assertEquals(3L, repository.rules().stream().filter(Rule::template).map(Rule::key).count());
 
         for (Rule rule : repository.rules()) {
             for (RulesDefinition.Param param : rule.params()) {

--- a/src/test/resources/required-key/required-key-01.yaml
+++ b/src/test/resources/required-key/required-key-01.yaml
@@ -1,0 +1,4 @@
+---
+key:
+  subkey: value
+  - syntax: error

--- a/src/test/resources/required-key/required-key-02.yaml
+++ b/src/test/resources/required-key/required-key-02.yaml
@@ -1,0 +1,4 @@
+---
+key:
+  kind: Deployment
+  readinessProbe: forbidden

--- a/src/test/resources/required-key/required-key-03.yaml
+++ b/src/test/resources/required-key/required-key-03.yaml
@@ -1,0 +1,4 @@
+---
+- key:
+  - subkey: value
+  - allowed: value

--- a/src/test/resources/required-key/required-key-04.yaml
+++ b/src/test/resources/required-key/required-key-04.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80

--- a/src/test/resources/required-key/required-key-05.yaml
+++ b/src/test/resources/required-key/required-key-05.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80

--- a/src/test/resources/required-key/required-key-06.yaml
+++ b/src/test/resources/required-key/required-key-06.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment2
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80

--- a/src/test/resources/required-key/required-key-07.yaml
+++ b/src/test/resources/required-key/required-key-07.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+          - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment2
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /api/he
+              scheme: HTTP
+              httpHeaders:
+                - name: Content-Type
+                  value: application/json
+              port: 80
+            initialDelaySeconds: 4
+            periodSeconds: 1
+            timeoutSeconds: 1
+            successThreshold: 3
+            failureThreshold: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment3
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80

--- a/src/test/resources/required-key/required-key-08.yaml
+++ b/src/test/resources/required-key/required-key-08.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa
+  namespace: namespace
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: deployment
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
### **New Template**

Hello, I'm Andres from Colombia. 
I work in a enterprise where we are going to use yaml plugin in order to validate some yaml files inside software projects. I have created a new template that I want to share you.

Sometimes we need that a specific yaml file contains some required key, perhaps because it is a good coding practice. 
To instance, Look this kubernetes yaml file:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.7.9
        ports:
        - containerPort: 80
```
This yaml could be better if it contains the readinessProbe and livenessProbe keys, because they guarantees stability for our microservices. So, this new template could validate that keys exists in that file.
This template require 3 parameters:
- **key-name**: Key name: e.g: kind
- **value-key**: Value for key: e.g: Deployment
- **required-key**: Required key. e.g: readinessProbe

**The key-name and value-key parameters are required because not all yaml files must to have the required-key, so it will filter yaml files.**

So, I have created this template that I hope other people can use it.
I'm going to attent some question that you could to have.
Have a nice day,