### PR TITLE
Ensure plugin compatibility with SonarQube 9.1+

### DIFF
--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/YamlPlugin.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/YamlPlugin.java
@@ -24,11 +24,14 @@ import com.github.sbaudoin.sonar.plugins.yaml.rules.YamlSensor;
 import com.github.sbaudoin.sonar.plugins.yaml.settings.YamlSettings;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.Plugin;
+import org.sonar.api.utils.Version;
 
 /**
  * Main plugin class
  */
 public class YamlPlugin implements Plugin {
+    static final Version SONARQUBE_WITH_YAML_SUPPORT_VERSION = Version.create(9, 1);
+
     public YamlPlugin() {
         // Disable INFO logs for Reflections (see )
         LoggerContext context = (LoggerContext)LoggerFactory.getILoggerFactory();
@@ -37,12 +40,19 @@ public class YamlPlugin implements Plugin {
 
     @Override
     public void define(Context context) {
-        context.addExtension(YamlLanguage.class);
-        context.addExtension(YamlQualityProfile.class);
+        boolean hasBuiltinYamlSupport = hasBuiltinYamlLanguageSupport(context);
+        if (!hasBuiltinYamlSupport) {
+            context.addExtension(YamlLanguage.class);
+        }
+        context.addExtension(new YamlQualityProfile(hasBuiltinYamlSupport));
 
         // Add plugin settings (file extensions, etc.)
-        context.addExtensions(YamlSettings.getProperties());
+        context.addExtensions(YamlSettings.getProperties(hasBuiltinYamlSupport));
 
         context.addExtensions(YamlRulesDefinition.class, YamlSensor.class);
+    }
+
+    public static boolean hasBuiltinYamlLanguageSupport(Context context) {
+        return context.getSonarQubeVersion().isGreaterThanOrEqual(SONARQUBE_WITH_YAML_SUPPORT_VERSION);
     }
 }

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/languages/YamlQualityProfile.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/languages/YamlQualityProfile.java
@@ -22,10 +22,16 @@ import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
  * Default, built-in quality profile for the projects having YAML files
  */
 public class YamlQualityProfile implements BuiltInQualityProfilesDefinition {
+    private final boolean hasBuiltinYamlSupport;
+
+    public YamlQualityProfile(boolean hasBuiltinYamlSupport) {
+        this.hasBuiltinYamlSupport = hasBuiltinYamlSupport;
+    }
+
     @Override
     public void define(Context context) {
-        NewBuiltInQualityProfile profile = context.createBuiltInQualityProfile("Sonar way", YamlLanguage.KEY);
-        profile.setDefault(true);
+        NewBuiltInQualityProfile profile = context.createBuiltInQualityProfile("YAML Analyzer", YamlLanguage.KEY);
+        profile.setDefault(!hasBuiltinYamlSupport);
 
         // Syntax error check
         profile.activateRule(CheckRepository.REPOSITORY_KEY, "ParsingErrorCheck");

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/settings/YamlSettings.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/settings/YamlSettings.java
@@ -19,9 +19,8 @@ import org.sonar.api.PropertyType;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import static java.util.Arrays.asList;
 
 /**
  * Wrapper class for the class settings
@@ -44,32 +43,40 @@ public class YamlSettings {
     /**
      * Returns the configuration properties of the plugin
      *
+     * @param hasBuiltinYamlSupport whether the SonarQube instance has embedded builtin support for the YAML language
      * @return the configuration properties of the plugin
      */
-    public static List<PropertyDefinition> getProperties() {
-        return asList(
+    public static List<PropertyDefinition> getProperties(boolean hasBuiltinYamlSupport) {
+        List<PropertyDefinition> properties = new ArrayList<>();
+        if(!hasBuiltinYamlSupport) {
+            properties.add(
                 PropertyDefinition.builder(FILE_SUFFIXES_KEY)
-                        .name("File Suffixes")
-                        .description("Comma-separated list of suffixes for files to analyze.")
-                        .defaultValue(FILE_SUFFIXES_DEFAULT_VALUE)
-                        .multiValues(true)
-                        .category("YAML")
-                        .onQualifiers(Qualifiers.PROJECT)
-                        .build(),
-                PropertyDefinition.builder(FILTER_UTF8_LB_KEY)
-                        .name("Filter UTF-8 Line Breaks")
-                        .description("Tells if UTF-8 line breaks (U+2028, U+2029 and U+0085) that may not be correctly supported by SonarQube are filtered out from the YAML code.")
-                        .type(PropertyType.BOOLEAN)
-                        .defaultValue("false")
-                        .category("YAML")
-                        .onQualifiers(Qualifiers.PROJECT)
-                        .build(),
-                PropertyDefinition.builder(YAML_LINT_CONF_PATH_KEY)
-                        .name("Path to a yamllint configuration file")
-                        .description("Path (absolute or relative to project root) to a yamllint configuration file. Leave it empty to use the default .yamllint file.")
-                        .defaultValue(YAML_LINT_CONF_PATH_DEFAULT_VALUE)
-                        .category("YAML")
-                        .onQualifiers(Qualifiers.PROJECT)
-                        .build());
+                    .name("File Suffixes")
+                    .description("Comma-separated list of suffixes for files to analyze.")
+                    .defaultValue(FILE_SUFFIXES_DEFAULT_VALUE)
+                    .multiValues(true)
+                    .category("YAML")
+                    .onQualifiers(Qualifiers.PROJECT)
+                    .build());
+        }
+
+        properties.add(
+            PropertyDefinition.builder(FILTER_UTF8_LB_KEY)
+                .name("Filter UTF-8 Line Breaks")
+                .description("Tells if UTF-8 line breaks (U+2028, U+2029 and U+0085) that may not be correctly supported by SonarQube are filtered out from the YAML code.")
+                .type(PropertyType.BOOLEAN)
+                .defaultValue("false")
+                .category("YAML")
+                .onQualifiers(Qualifiers.PROJECT)
+                .build());
+        properties.add(
+            PropertyDefinition.builder(YAML_LINT_CONF_PATH_KEY)
+                .name("Path to a yamllint configuration file")
+                .description("Path (absolute or relative to project root) to a yamllint configuration file. Leave it empty to use the default .yamllint file.")
+                .defaultValue(YAML_LINT_CONF_PATH_DEFAULT_VALUE)
+                .category("YAML")
+                .onQualifiers(Qualifiers.PROJECT)
+                .build());
+        return properties;
     }
 }

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/YamlPluginTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/YamlPluginTest.java
@@ -27,4 +27,10 @@ public class YamlPluginTest extends TestCase {
         new YamlPlugin().define(context);
         assertEquals(7, context.getExtensions().size());
     }
+
+    public void testExtensionCountsWithYamlBuiltinSupport() {
+        Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(YamlPlugin.SONARQUBE_WITH_YAML_SUPPORT_VERSION, SonarQubeSide.SERVER));
+        new YamlPlugin().define(context);
+        assertEquals(5, context.getExtensions().size());
+    }
 }

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/languages/YamlQualityProfileTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/languages/YamlQualityProfileTest.java
@@ -19,13 +19,23 @@ import junit.framework.TestCase;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 
 public class YamlQualityProfileTest extends TestCase {
-    public void testDefine() {
+    public void testDefineWithoutYamlBuiltinSupport() {
         BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
-        YamlQualityProfile qp = new YamlQualityProfile();
+        YamlQualityProfile qp = new YamlQualityProfile(false);
         qp.define(context);
-        BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile("yaml", "Sonar way");
+        BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile("yaml", "YAML Analyzer");
         assertNotNull(profile);
         assertTrue(profile.isDefault());
+        assertEquals(19, profile.rules().size());
+    }
+
+    public void testDefineWithYamlBuiltinSupport() {
+        BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
+        YamlQualityProfile qp = new YamlQualityProfile(true);
+        qp.define(context);
+        BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile("yaml", "YAML Analyzer");
+        assertNotNull(profile);
+        assertFalse(profile.isDefault());
         assertEquals(19, profile.rules().size());
     }
 }

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/settings/YamlLanguageSettingsTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/settings/YamlLanguageSettingsTest.java
@@ -21,8 +21,8 @@ import org.sonar.api.config.PropertyDefinition;
 import java.util.List;
 
 public class YamlLanguageSettingsTest extends TestCase {
-    public void testGetProperties() {
-        List<PropertyDefinition> defs = YamlSettings.getProperties();
+    public void testGetPropertiesWithoutYamlBuiltinSupport() {
+        List<PropertyDefinition> defs = YamlSettings.getProperties(false);
 
         assertEquals(3, defs.size());
         assertEquals(YamlSettings.FILE_SUFFIXES_KEY, defs.get(0).key());
@@ -31,5 +31,15 @@ public class YamlLanguageSettingsTest extends TestCase {
         assertEquals("false", defs.get(1).defaultValue());
         assertEquals(YamlSettings.YAML_LINT_CONF_PATH_KEY, defs.get(2).key());
         assertEquals("", defs.get(2).defaultValue());
+    }
+
+    public void testGetPropertiesWithYamlBuiltinSupport() {
+        List<PropertyDefinition> defs = YamlSettings.getProperties(true);
+
+        assertEquals(2, defs.size());
+        assertEquals(YamlSettings.FILTER_UTF8_LB_KEY, defs.get(0).key());
+        assertEquals("false", defs.get(0).defaultValue());
+        assertEquals(YamlSettings.YAML_LINT_CONF_PATH_KEY, defs.get(1).key());
+        assertEquals("", defs.get(1).defaultValue());
     }
 }


### PR DESCRIPTION
Hello @sbaudoin,

The next SonarQube version (9.1) will come with an embedded plugin that will already define the YAML language. This is added to SonarQube in order to easily index YAML configuration files, so that these files are available to our other analyzers.
In order to avoid breaking compatibility, 'sonar-yaml-plugin' would need to be slightly adapted to only register extensions when they are necessary, starting from SonarQube 9.1.

Here is a summary of the suggested changes of this PR in order to maintain compatibility:
- The `YamlLanguage` class and its corresponding file suffixes property are only registered by the plugin up to version 9.0 of SonarQube.
- `YamlQualityProfile` is renamed from “Sonar way” to “YAML Analyzer” to avoid naming conflict with the embedded profile.
- `YamlQualityProfile` is only set as default builtin quality profile for versions of SonarQube lower than 9.1.

Let me know if you have any questions.