### PR TITLE
Update yamllint to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.github.sbaudoin</groupId>
             <artifactId>yamllint</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
I'm having this error in sonarqube 9.9
```
WARN: Cannot get YamlLintConfig for rule 'quoted-strings'
com.github.sbaudoin.yamllint.YamlLintConfigException: invalid YAML config: while scanning a quoted scalar
```

[yamllint](https://github.com/sbaudoin/yamllint/releases) v1.5.0 states:
Fixed the rule 'quoted-strings' for explicit octal recognition
Fixed the 'line_length' rule to skip all hash signs starting comment