### PR TITLE
Fix #86 - catch "Trying to save highlighting twice"

### DIFF
--- a/it/audit.sh
+++ b/it/audit.sh
@@ -22,7 +22,10 @@ fi
 
 # Check for warnings
 # Ugly fix for SQ 9.8+ that has deprecated login/password authentication but still allows it.
-if grep -iv "propert.* 'sonar.password' .* deprecated" /tmp/scanner.log | grep -q "^WARN: "
+# Also ignore expected warnings regarding k8s.yaml
+if grep -iv "propert.* 'sonar.password' .* deprecated" /tmp/scanner.log \
+ | grep -v "Cannot save .* k8s.yml, ignoring" \
+ | grep -q "^WARN: "
 then
     echo "Warnings found" >&2
     exit 1
@@ -78,21 +81,21 @@ if 'component' not in data or 'measures' not in data['component']:
 
 lines = ncloc = files = directories = comment_lines = False
 for measure in data['component']['measures']:
-    if measure['metric'] == 'lines' and measure['value'] == '16':
+    if measure['metric'] == 'lines' and measure['value'] == '31':
         print('lines metrics OK')
         lines = True
-#    if measure['metric'] == 'ncloc' and measure['value'] == '13':
+#    if measure['metric'] == 'ncloc' and measure['value'] == '27':
 #        print('ncloc metrics OK')
 #        ncloc = True
     ncloc = True
-    if measure['metric'] == 'files' and measure['value'] == '2':
+    if measure['metric'] == 'files' and measure['value'] == '3':
         print('files metrics OK')
         files = True
 #    if measure['metric'] == 'directories' and measure['value'] == '2':
 #        print('directories metrics OK')
 #        directories = True
     directories = True
-#    if measure['metric'] == 'comment_lines' and measure['value'] == '1':
+#    if measure['metric'] == 'comment_lines' and measure['value'] == '2':
 #        print('comment_lines metrics OK')
 #        comment_lines = True
     comment_lines = True

--- a/it/src/k8s.yml
+++ b/it/src/k8s.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+spec:
+  containers:
+    - name: web
+      image: nginx
+      ports:
+        - name: web
+          containerPort: 80
+          protocol: TCP
+      securityContext:
+        privileged: true # Sensitive

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/linecounter/LineCounter.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/linecounter/LineCounter.java
@@ -79,7 +79,12 @@ public class LineCounter {
         } catch (UnsupportedOperationException e) {
             // If another plugin has already saved measures for the file then we get this exception
             // As sensors are not supposed to read measures, there is no other way to proceed.
-            LOGGER.warn("Cannot save measures for file " + yamlFile.filename() + ", ignoring them", e);
+            String msg = "Cannot save measures for file " + yamlFile.filename() + ", ignoring them";
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.warn(msg, e);
+            } else {
+                LOGGER.warn(msg);
+            }
             return;
         }
 

--- a/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlSensor.java
+++ b/src/main/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlSensor.java
@@ -311,7 +311,17 @@ public class YamlSensor implements Sensor {
         for (HighlightingData highlightingData : highlightingDataList) {
             highlightingData.highlight(highlighting);
         }
-        highlighting.save();
+        try {
+            highlighting.save();
+        } catch (UnsupportedOperationException e) {
+            String msg = "Cannot save highlighting for file " + sourceCode.getYamlFile().filename() + ", ignoring";
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.warn(msg, e);
+            } else {
+                LOGGER.warn(msg);
+            }
+            return;
+        }
     }
 
     /**

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlSensorTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlSensorTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+import org.mockito.AdditionalAnswers;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.sonar.api.batch.fs.InputFile;
@@ -35,7 +36,10 @@ import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.rule.internal.NewActiveRule;
 import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.batch.sensor.highlighting.NewHighlighting;
+import org.sonar.api.batch.sensor.highlighting.internal.DefaultHighlighting;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.internal.SensorStorage;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -53,6 +57,7 @@ import java.util.function.Predicate;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
@@ -148,7 +153,26 @@ public class YamlSensorTest {
     }
 
     @Test
+    public void testSensorHighlightingUnsupportedOperationException() throws Exception {
+        init(false);
+
+        SensorContextTester myContext = mock(SensorContextTester.class, AdditionalAnswers.delegatesTo(context));
+        SensorStorage myStorage = mock(SensorStorage.class);
+        NewHighlighting myHighlighting = mock(NewHighlighting.class, AdditionalAnswers.delegatesTo(new RedundantHighlighting(myStorage)));
+        doReturn(myHighlighting).when(myContext).newHighlighting();
+
+        InputFile inputFile = Utils.getInputFile("k8s.yml");
+        fs.add(inputFile);
+
+        sensor.execute(myContext);
+        assertEquals(1, logTester.logs(LoggerLevel.WARN).size());
+        assertEquals("Cannot save highlighting for file k8s.yml, ignoring", logTester.logs(LoggerLevel.WARN).get(0));
+        assertEquals(0, myContext.allIssues().size());
+    }
+
+    @Test
     public void testGlobalConfig0() throws Exception {
+        cleanEnv();
         init(false);
         assertNull(sensor.localConfig);
     }
@@ -317,6 +341,18 @@ public class YamlSensorTest {
         @Override
         public SensorDescriptor onlyWhenConfiguration(Predicate<Configuration> predicate) {
             return this;
+        }
+    }
+
+    private static class RedundantHighlighting extends DefaultHighlighting {
+        public RedundantHighlighting(SensorStorage storage) {
+            super(storage);
+        }
+
+        @Override
+        public void doSave() {
+            // that's what would happen if some highlighting had already been saved for same file
+            throw new UnsupportedOperationException("Blam!");
         }
     }
 }

--- a/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlSensorTest.java
+++ b/src/test/java/com/github/sbaudoin/sonar/plugins/yaml/rules/YamlSensorTest.java
@@ -252,6 +252,7 @@ public class YamlSensorTest {
 
     @After
     public void cleanEnv() throws IOException {
+        System.clearProperty("user.home");
         environmentVariables.clear(Cli.XDG_CONFIG_HOME_ENV_VAR, Cli.YAMLLINT_CONFIG_FILE_ENV_VAR);
         Files.deleteIfExists(Utils.BASE_DIR.resolve(Cli.USER_CONF_FILENAME));
         Files.deleteIfExists(Utils.BASE_DIR.resolve(Cli.USER_CONF_FILENAME + ".yaml"));

--- a/src/test/resources/k8s.yml
+++ b/src/test/resources/k8s.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+spec:
+  containers:
+    - name: web
+      image: nginx
+      ports:
+        - name: web
+          containerPort: 80
+          protocol: TCP
+      securityContext:
+        privileged: true # Sensitive


### PR DESCRIPTION
Fix #86.

- catch the `UnsupportedOperationException: Trying to save highlighting twice` on k8s files, and continue despite the error, not saving highlighting
- add a k8s YAML file to integration tests (generates 2 warnings in the scanner log, which are expected and thus ignored); the example comes from [S6428](https://sqaas.dos.tech.orange/coding_rules?languages=kubernetes&open=kubernetes%3AS6428)
- be less verbose on the `WARN: Cannot save measures for...` (only print full exception if in debug mode, otherwise it becomes noisy/scary when analysing a project with many such errors)